### PR TITLE
Ciede2k norm

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -43,7 +43,8 @@ TEST_OBJ=$(OUTTESTS)/assembler_unittests.o                                     \
          $(OUTTESTS)/range_unittests.o                                         \
          $(OUTTESTS)/serialization_unittests.o
 
-all: $(OUT)/fit                                                                \
+all: $(OUT)/find_ciede_max_distance                                            \
+     $(OUT)/fit                                                                \
      $(OUT)/gen                                                                \
      $(OUT)/pcm                                                                \
      $(OUT)/respec                                                             \
@@ -62,6 +63,10 @@ $(OUTTESTS)/%.o: %.cc $(DEPS) | $(OUTTESTS)/
 $(OUT)/build_error_distances: $(IMAGE_OBJ) $(COLOR_OBJ)                        \
                               $(OUT)/build_error_distances.o
 	$(CC) -o $@ $^ $(LIBZ26_LIB) $(GFLAGS_LIB) $(CFLAGS) $(LDFLAGS) $(LIBS)
+
+$(OUT)/find_ciede_max_distance: $(OBJ) $(IMAGE_OBJ) $(COLOR_OBJ)               \
+            $(OUT)/color_distance_table.o $(OUT)/find_ciede_max_distance.o
+	$(CC) -o $@ $^ $(LIBZ26_LIB) $(CFLAGS) $(LDFLAGS) $(LIBS)
 
 $(OUT)/fit: $(OBJ) $(IMAGE_OBJ) $(COLOR_OBJ) $(OUT)/fit.o                      \
             $(OUT)/color_distance_table.o

--- a/src/build_error_distances.cc
+++ b/src/build_error_distances.cc
@@ -55,6 +55,8 @@ int main(int argc, char* argv[]) {
     }
   }
 
+  printf("max distance: %.19g\n", max_distance);
+
   // Save code file of computed distances.
   std::string code_path = FLAGS_output_directory + "/" +
       "color_distance_table.cc";

--- a/src/constants.h
+++ b/src/constants.h
@@ -22,6 +22,11 @@ const uint32 kNTSCColors = 128;
 const uint32 kInfinity = 0xffffffff;
 const double kClockRateHz = 76.0 * 262.0 * 60.0;
 
+// Computed by exploring distance between all 128 Atari colors and all possible
+// 24 bit RGB colors in find_ciede_max_distance.cc. If the Atari palette changes
+// this value will need to be recomputed.
+const double kMaxCiede2kDistance = 109.1780286805052782;
+
 // Screen vertical dimensions/timing constants.
 const uint32 kVSyncScanLines = 3;
 const uint32 kVBlankScanLines = 37;

--- a/src/find_ciede_max_distance.cc
+++ b/src/find_ciede_max_distance.cc
@@ -83,7 +83,7 @@ int main(int argc, char* argv[]) {
     double completion = (static_cast<double>(total_evals) * 100.0) /
         static_cast<double>(kTotalEvals);
     printf("percent done: %3.7f, rate per second: %" PRIu64 
-        ", eta in seconds: %" PRIu64 "\n",
+        ", eta in seconds: %" PRIu64 " ",
         completion, rate, eta);
     MaxDistance md = max_distances.combine(
         [](const MaxDistance& md_a, const MaxDistance& md_b) {
@@ -91,7 +91,7 @@ int main(int argc, char* argv[]) {
           return md_b;
         });
 
-    printf("max distance: %.19g, bgr_a: %6x, bgr_b: %6x\n",
+    printf("max distance: %.19g, bgr_a: %06x, bgr_b: %06x\n",
         md.distance, md.color_a, md.color_b);
 
     start_range = end_range;

--- a/src/find_ciede_max_distance.cc
+++ b/src/find_ciede_max_distance.cc
@@ -2,20 +2,17 @@
 // Ciede2K distance between any two RGB colors. Used for normalizing Ciede2K
 // distances to [0, 1] range.
 
-#include <chrono>
-#include <cinttypes>
 #include <stdio.h>
 
 #include "tbb/tbb.h"
 
 #include "color.h"
+#include "color_table.h"
+#include "constants.h"
 #include "types.h"
 
-static const uint32 kStartColorABGR = 0x00000000;
-static const uint32 kStopColorABGR = 0x00ffffff;
-static const uint64 kTotalEvals = static_cast<uint64>(kStopColorABGR) *
-    static_cast<uint64>(kStopColorABGR / 2);
-static const uint32 kStepSize = 255;
+const uint32 kStartColorABGR = 0x00000000;
+const uint32 kStopColorABGR = 0x00ffffff;
 
 struct MaxDistance {
  public:
@@ -38,10 +35,9 @@ class SearchABGRJob {
     for (uint32 i = r.begin(); i < r.end(); ++i) {
       double lab_a[4];
       vcsmc::RGBAToLabA(reinterpret_cast<const uint8*>(&i), lab_a);
-      for (uint32 j = i + 1; j <= kStopColorABGR; ++j) {
-        double lab_b[4];
-        vcsmc::RGBAToLabA(reinterpret_cast<const uint8*>(&j), lab_b);
-        double distance = vcsmc::Ciede2k(lab_a, lab_b);
+      for (uint32 j = 0; j < vcsmc::kNTSCColors; ++j) {
+        double distance = vcsmc::Ciede2k(lab_a,
+            vcsmc::kAtariNTSCLabColorTable + (4 * j));
         if (distance > local_max_distance.distance) {
           local_max_distance.color_a = i;
           local_max_distance.color_b = j;
@@ -60,43 +56,18 @@ int main(int argc, char* argv[]) {
   (void)argv;
 
   MaxDistances max_distances;
-  uint32 start_range = kStartColorABGR;
-  uint32 end_range = start_range + kStepSize;
-  uint64 total_evals = 0;
 
-  while (start_range < kStopColorABGR) {
-    auto start_of_run = std::chrono::high_resolution_clock::now();
-    tbb::parallel_for(
-        tbb::blocked_range<uint32>(start_range, end_range),
-        SearchABGRJob(max_distances));
-    auto end_of_run = std::chrono::high_resolution_clock::now();
-    uint64 time_us = std::chrono::duration_cast<std::chrono::microseconds>(
-        end_of_run - start_of_run).count();
+  tbb::parallel_for(
+      tbb::blocked_range<uint32>(kStartColorABGR, kStopColorABGR),
+      SearchABGRJob(max_distances));
+  MaxDistance md = max_distances.combine(
+      [](const MaxDistance& md_a, const MaxDistance& md_b) {
+        if (md_a.distance > md_b.distance) return md_a;
+        return md_b;
+      });
 
-    uint64 evals = 0;
-    for (uint32 i = start_range; i < end_range; ++i) {
-      evals += kStopColorABGR - i;
-    }
-    total_evals += evals;
-    uint64 rate = (evals * 100000) / time_us;
-    uint64 eta = (kTotalEvals - evals) / rate;
-    double completion = (static_cast<double>(total_evals) * 100.0) /
-        static_cast<double>(kTotalEvals);
-    printf("percent done: %3.7f, rate per second: %" PRIu64 
-        ", eta in seconds: %" PRIu64 " ",
-        completion, rate, eta);
-    MaxDistance md = max_distances.combine(
-        [](const MaxDistance& md_a, const MaxDistance& md_b) {
-          if (md_a.distance > md_b.distance) return md_a;
-          return md_b;
-        });
-
-    printf("max distance: %.19g, bgr_a: %06x, bgr_b: %06x\n",
-        md.distance, md.color_a, md.color_b);
-
-    start_range = end_range;
-    end_range = std::min(start_range + kStepSize, kStopColorABGR + 1);
-  }
+  printf("max distance: %.19g, bgr_a: %06x, bgr_b: %06x\n",
+      md.distance, md.color_a, md.color_b);
 
   return 0;
 }

--- a/src/find_ciede_max_distance.cc
+++ b/src/find_ciede_max_distance.cc
@@ -62,19 +62,22 @@ int main(int argc, char* argv[]) {
   MaxDistances max_distances;
   uint32 start_range = kStartColorABGR;
   uint32 end_range = start_range + kStepSize;
-  uint64 evals = 0;
+  uint64 total_evals = 0;
 
-  auto start_of_run = std::chrono::high_resolution_clock::now();
   while (start_range < kStopColorABGR) {
+    auto start_of_run = std::chrono::high_resolution_clock::now();
     tbb::parallel_for(
         tbb::blocked_range<uint32>(start_range, end_range),
         SearchABGRJob(max_distances));
     auto end_of_run = std::chrono::high_resolution_clock::now();
     uint64 time_us = std::chrono::duration_cast<std::chrono::microseconds>(
         end_of_run - start_of_run).count();
+
+    uint64 evals = 0;
     for (uint32 i = start_range; i < end_range; ++i) {
       evals += kStopColorABGR - i;
     }
+    total_evals += evals;
     uint64 rate = (evals * 100000) / time_us;
     uint64 eta = (kTotalEvals - evals) / rate;
 

--- a/src/find_ciede_max_distance.cc
+++ b/src/find_ciede_max_distance.cc
@@ -3,6 +3,7 @@
 // distances to [0, 1] range.
 
 #include <chrono>
+#include <cinttypes>
 #include <stdio.h>
 
 #include "tbb/tbb.h"
@@ -77,7 +78,8 @@ int main(int argc, char* argv[]) {
     uint64 rate = (evals * 100000) / time_us;
     uint64 eta = (kTotalEvals - evals) / rate;
 
-    printf("rate per second: %llu, eta in seconds: %llu\n", rate, eta);
+    printf("rate per second: %" PRIu64 ", eta in seconds: %" PRIu64 "\n",
+        rate, eta);
 
     start_range = end_range;
     end_range = std::min(start_range + kStepSize, kStopColorABGR + 1);

--- a/src/find_ciede_max_distance.cc
+++ b/src/find_ciede_max_distance.cc
@@ -85,18 +85,18 @@ int main(int argc, char* argv[]) {
     printf("percent done: %3.7f, rate per second: %" PRIu64 
         ", eta in seconds: %" PRIu64 "\n",
         completion, rate, eta);
+    MaxDistance md = max_distances.combine(
+        [](const MaxDistance& md_a, const MaxDistance& md_b) {
+          if (md_a.distance > md_b.distance) return md_a;
+          return md_b;
+        });
+
+    printf("max distance: %.19g, abgr_a: %x, abgr_b: %x\n",
+        md.distance, md.color_a, md.color_b);
 
     start_range = end_range;
     end_range = std::min(start_range + kStepSize, kStopColorABGR + 1);
   }
 
-  MaxDistance md = max_distances.combine(
-      [](const MaxDistance& md_a, const MaxDistance& md_b) {
-        if (md_a.distance > md_b.distance) return md_a;
-        return md_b;
-      });
-
-  printf("max distance: %.19g, abgr_a: %x, abgr_b: %x\n",
-      md.distance, md.color_a, md.color_b);
   return 0;
 }

--- a/src/find_ciede_max_distance.cc
+++ b/src/find_ciede_max_distance.cc
@@ -80,9 +80,11 @@ int main(int argc, char* argv[]) {
     total_evals += evals;
     uint64 rate = (evals * 100000) / time_us;
     uint64 eta = (kTotalEvals - evals) / rate;
-
-    printf("rate per second: %" PRIu64 ", eta in seconds: %" PRIu64 "\n",
-        rate, eta);
+    double completion = (static_cast<double>(total_evals) * 100.0) /
+        static_cast<double>(kTotalEvals);
+    printf("percent done: %3.7f, rate per second: %" PRIu64 
+        ", eta in seconds: %" PRIu64 "\n",
+        completion, rate, eta);
 
     start_range = end_range;
     end_range = std::min(start_range + kStepSize, kStopColorABGR + 1);

--- a/src/find_ciede_max_distance.cc
+++ b/src/find_ciede_max_distance.cc
@@ -2,6 +2,7 @@
 // Ciede2K distance between any two RGB colors. Used for normalizing Ciede2K
 // distances to [0, 1] range.
 
+#include <chrono>
 #include <stdio.h>
 
 #include "tbb/tbb.h"
@@ -11,6 +12,9 @@
 
 static const uint32 kStartColorABGR = 0x00000000;
 static const uint32 kStopColorABGR = 0x00ffffff;
+static const uint64 kTotalEvals = (kStopColorABGR - kStartColorABGR) *
+  ((kStopColorABGR - kStartColorABGR) / 2);
+static const uint32 kStepSize = 255;
 
 struct MaxDistance {
  public:
@@ -33,7 +37,7 @@ class SearchABGRJob {
     for (uint32 i = r.begin(); i < r.end(); ++i) {
       double lab_a[4];
       vcsmc::RGBAToLabA(reinterpret_cast<const uint8*>(&i), lab_a);
-      for (uint32 j = i; j <= kStopColorABGR; ++j) {
+      for (uint32 j = i + 1; j <= kStopColorABGR; ++j) {
         double lab_b[4];
         vcsmc::RGBAToLabA(reinterpret_cast<const uint8*>(&j), lab_b);
         double distance = vcsmc::Ciede2k(lab_a, lab_b);
@@ -55,9 +59,29 @@ int main(int argc, char* argv[]) {
   (void)argv;
 
   MaxDistances max_distances;
-  tbb::parallel_for(
-      tbb::blocked_range<uint32>(kStartColorABGR, kStopColorABGR + 1),
-      SearchABGRJob(max_distances));
+  uint32 start_range = kStartColorABGR;
+  uint32 end_range = start_range + kStepSize;
+  uint64 evals = 0;
+
+  auto start_of_run = std::chrono::high_resolution_clock::now();
+  while (start_range < kStopColorABGR) {
+    tbb::parallel_for(
+        tbb::blocked_range<uint32>(start_range, end_range),
+        SearchABGRJob(max_distances));
+    auto end_of_run = std::chrono::high_resolution_clock::now();
+    uint64 time_us = std::chrono::duration_cast<std::chrono::microseconds>(
+        end_of_run - start_of_run).count();
+    for (uint32 i = start_range; i < end_range; ++i) {
+      evals += kStopColorABGR - i;
+    }
+    uint64 rate = (evals * 100000) / time_us;
+    uint64 eta = (kTotalEvals - evals) / rate;
+
+    printf("rate per second: %llu, eta in seconds: %llu\n", rate, eta);
+
+    start_range = end_range;
+    end_range = std::min(start_range + kStepSize, kStopColorABGR + 1);
+  }
 
   MaxDistance md = max_distances.combine(
       [](const MaxDistance& md_a, const MaxDistance& md_b) {

--- a/src/find_ciede_max_distance.cc
+++ b/src/find_ciede_max_distance.cc
@@ -91,7 +91,7 @@ int main(int argc, char* argv[]) {
           return md_b;
         });
 
-    printf("max distance: %.19g, abgr_a: %x, abgr_b: %x\n",
+    printf("max distance: %.19g, bgr_a: %6x, bgr_b: %6x\n",
         md.distance, md.color_a, md.color_b);
 
     start_range = end_range;

--- a/src/find_ciede_max_distance.cc
+++ b/src/find_ciede_max_distance.cc
@@ -1,0 +1,71 @@
+// find_ciede_max_distance - searches RGB 24-bit color space for the maximum
+// Ciede2K distance between any two RGB colors. Used for normalizing Ciede2K
+// distances to [0, 1] range.
+
+#include <stdio.h>
+
+#include "tbb/tbb.h"
+
+#include "color.h"
+#include "types.h"
+
+static const uint32 kStartColorABGR = 0x00000000;
+static const uint32 kStopColorABGR = 0x00ffffff;
+
+struct MaxDistance {
+ public:
+  MaxDistance() : color_a(0), color_b(0), distance(0) {}
+
+  uint32 color_a;
+  uint32 color_b;
+  double distance;
+};
+
+typedef tbb::combinable<MaxDistance> MaxDistances;
+
+class SearchABGRJob {
+ public:
+  SearchABGRJob(MaxDistances& max_distances)
+    : max_distances_(max_distances) {}
+
+  void operator()(const tbb::blocked_range<uint32>& r) const {
+    MaxDistance& local_max_distance = max_distances_.local();
+    for (uint32 i = r.begin(); i < r.end(); ++i) {
+      double lab_a[4];
+      vcsmc::RGBAToLabA(reinterpret_cast<const uint8*>(&i), lab_a);
+      for (uint32 j = i; j <= kStopColorABGR; ++j) {
+        double lab_b[4];
+        vcsmc::RGBAToLabA(reinterpret_cast<const uint8*>(&j), lab_b);
+        double distance = vcsmc::Ciede2k(lab_a, lab_b);
+        if (distance > local_max_distance.distance) {
+          local_max_distance.color_a = i;
+          local_max_distance.color_b = j;
+          local_max_distance.distance = distance;
+        }
+      }
+    }
+  }
+
+ private:
+  MaxDistances& max_distances_;
+};
+
+int main(int argc, char* argv[]) {
+  (void)argc;
+  (void)argv;
+
+  MaxDistances max_distances;
+  tbb::parallel_for(
+      tbb::blocked_range<uint32>(kStartColorABGR, kStopColorABGR + 1),
+      SearchABGRJob(max_distances));
+
+  MaxDistance md = max_distances.combine(
+      [](const MaxDistance& md_a, const MaxDistance& md_b) {
+        if (md_a.distance > md_b.distance) return md_a;
+        return md_b;
+      });
+
+  printf("max distance: %.19g, abgr_a: %x, abgr_b: %x\n",
+      md.distance, md.color_a, md.color_b);
+  return 0;
+}

--- a/src/find_ciede_max_distance.cc
+++ b/src/find_ciede_max_distance.cc
@@ -13,8 +13,8 @@
 
 static const uint32 kStartColorABGR = 0x00000000;
 static const uint32 kStopColorABGR = 0x00ffffff;
-static const uint64 kTotalEvals = (kStopColorABGR - kStartColorABGR) *
-  ((kStopColorABGR - kStartColorABGR) / 2);
+static const uint64 kTotalEvals = static_cast<uint64>(kStopColorABGR) *
+    static_cast<uint64>(kStopColorABGR / 2);
 static const uint32 kStepSize = 255;
 
 struct MaxDistance {


### PR DESCRIPTION
for calculation of normalized ciede2k color distances between atari colors and arbitrary RGB colors I wrote a program to search all 24 bit RGB colors against all Atari colors for max CIEDE2k distance. This value can be used to divide CIEDE2K distances to be sure that all distances are normalized between [0,1].